### PR TITLE
NCSD-71 Keyvault issue

### DIFF
--- a/ArmTemplates/keyvault-secrets.json
+++ b/ArmTemplates/keyvault-secrets.json
@@ -29,7 +29,7 @@
             "tags": {},
             "properties": {
                 "contentType": "[parameters('secrets')[copyIndex()].type]",
-                "value": "[parameters('secrets')[copyIndex()].type]"            
+                "value": "[parameters('secrets')[copyIndex()].secret]"            
             }
         }
     ],

--- a/ArmTemplates/keyvault.json
+++ b/ArmTemplates/keyvault.json
@@ -22,8 +22,21 @@
                     "family": "A",
                     "name": "standard"
                 },
-                "accessPolicies": [],
                 "tenantId": "[subscription().tenantId]",
+                "accessPolicies": [
+                    {
+                        "tenantId": "[subscription().tenantId]",
+                        "objectId": "7fa23fd6-537e-4d28-b0ca-54d075cce842",
+                        "permissions": {
+                            "keys": [],
+                            "secrets": [
+                                "get"
+                            ],
+                            "certificates": [],
+                            "storage": []
+                        }
+                    }
+                ],
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,
                 "enabledForTemplateDeployment": false

--- a/ArmTemplates/keyvault.json
+++ b/ArmTemplates/keyvault.json
@@ -22,6 +22,7 @@
                     "family": "A",
                     "name": "standard"
                 },
+                "accessPolicies": [],
                 "tenantId": "[subscription().tenantId]",
                 "enabledForDeployment": false,
                 "enabledForDiskEncryption": false,

--- a/ArmTemplates/keyvault.md
+++ b/ArmTemplates/keyvault.md
@@ -1,6 +1,8 @@
 # KeyVault
 
-Creates a key vault with App Service access
+Creates a key vault.
+If ran on an existing key vault it will wipe out all existing access policies.
+For an alternative which only creates the key vault if one does not exist, see PSScript/New-KeyVault.ps1
 
 ## Paramaters
 

--- a/PSScripts/New-KeyVault.ps1
+++ b/PSScripts/New-KeyVault.ps1
@@ -31,7 +31,8 @@ else {
     Write-Host "Creating key vault $KeyVaultName"
     $ResourceGroup = Get-AzureRmResourceGroup -Name $ResourceGroupName
 
-    if ((((Get-Module AzureRM -ListAvailable | Sort-Object { $_.Version.Major } -Descending).Version.Major))[0] -gt 5) {
+    $AzureRmVersion = Get-Module AzureRM -ListAvailable | Sort-Object { $_.Version.Major } -Descending | Select-Object -First 1
+    if ($AzureRmVersion.Version.Major -gt 5) {
         $NewKeyVault   = New-AzureRmKeyVault -Name $KeyVaultName -ResourceGroupName $ResourceGroup.ResourceGroupName -Location $ResourceGroup.Location
     }
     else {

--- a/PSScripts/New-KeyVault.ps1
+++ b/PSScripts/New-KeyVault.ps1
@@ -30,6 +30,13 @@ if ($ExistingKeyVault) {
 else {
     Write-Host "Creating key vault $KeyVaultName"
     $ResourceGroup = Get-AzureRmResourceGroup -Name $ResourceGroupName
-    $NewKeyVault   = New-AzureRmKeyVault -name $KeyVaultName -ResourceGroupName $ResourceGroup.ResourceGroupName -Location $ResourceGroup.Location
+
+    if ((((Get-Module AzureRM -ListAvailable | Sort-Object { $_.Version.Major } -Descending).Version.Major))[0] -gt 5) {
+        $NewKeyVault   = New-AzureRmKeyVault -Name $KeyVaultName -ResourceGroupName $ResourceGroup.ResourceGroupName -Location $ResourceGroup.Location
+    }
+    else {
+        $NewKeyVault   = New-AzureRmKeyVault -VaultName $KeyVaultName -ResourceGroupName $ResourceGroup.ResourceGroupName -Location $ResourceGroup.Location
+    }
+
     Remove-AzureRmKeyVaultAccessPolicy -VaultName $NewKeyVault.VaultName -ObjectId $NewKeyVault.AccessPolicies[0].ObjectId
 }

--- a/PSScripts/New-KeyVault.ps1
+++ b/PSScripts/New-KeyVault.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+Creates a key vault if one does not exist
+
+.DESCRIPTION
+Creates a key vault if one does not exist
+
+.PARAMETER KeyVaultName
+Keyvault to add the secret to
+
+.PARAMETER ResourceGroupName
+Resource Group for the key vault
+
+.EXAMPLE
+New-KeyVault -KeyVaultName dfc-foo-kv -ResourceGroupName dfc-foo-rg
+
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $KeyVaultName,
+    [Parameter(Mandatory=$true)]
+    [string] $ResourceGroupName
+)
+
+$ExistingKeyVault = Get-AzureRmKeyVault $KeyVaultName -ResourceGroupName $ResourceGroupName
+
+if ($ExistingKeyVault) {
+    Write-Host "Key vault $KeyVaultName already exists"
+}
+else {
+    Write-Host "Creating key vault $KeyVaultName"
+    $ResourceGroup = Get-AzureRmResourceGroup -Name $ResourceGroupName
+    $NewKeyVault   = New-AzureRmKeyVault -name $KeyVaultName -ResourceGroupName $ResourceGroup.ResourceGroupName -Location $ResourceGroup.Location
+    Remove-AzureRmKeyVaultAccessPolicy -VaultName $NewKeyVault.VaultName -ObjectId $NewKeyVault.AccessPolicies[0].ObjectId
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A sample master template and links to individual deployment documentation can be
 
 ## PowerShell Scripts
 
+The PowerShell scripts directory contains scripts that can be used either in build and release definitions or from the command line.
+
 ## Tests
 
 All PowerShell scripts and ARM templates should be covered by Pester tests.

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -7,11 +7,7 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a single key vault secret added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = @( @{ 
-        name   = "foo"
-        secret = "bar"
-        type   = ""
-      } )
+      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret":" "bar", "type":" "" }]'
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName
@@ -30,15 +26,8 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a multiple secrets added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = @( @{ 
-        name   = "foo"
-        secret = "bar"
-        type   = ""
-      }, @{
-        name   = "foo2"
-        secret = "bar2"
-        type   = "text/plain"
-      } )
+      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret":" "bar", "type":" "" },
+                      { "name": "foo2", "secret":" "another secret", "type":" "text/plain" }]'
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a single key vault secret added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret":" "bar", "type":" "" }]')
+      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret": "bar", "type":" "" }]')
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName
@@ -26,8 +26,8 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a multiple secrets added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret":" "bar", "type":" "" },
-                      { "name": "foo2", "secret":" "another secret", "type":" "text/plain" }]'
+      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret": "bar", "type":" "" },
+                      { "name": "foo2", "secret": "another secret", "type":" "text/plain" }]'
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -1,0 +1,57 @@
+# common variables
+$ResourceGroupName = "dfc-test-template-rg"
+$TemplateFile = "$PSScriptRoot\..\ArmTemplates\keyvault.json"
+
+Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
+  
+  Context "When a single key vault secret added" {
+    $TemplateParameters = @{
+      keyVaultName = "dfc-foo-bar-kv"
+      secrets      = @( @{ 
+        name   = "foo"
+        secret = "bar"
+        type   = ""
+      } )
+    }
+    $TestTemplateParams = @{
+      ResourceGroupName       = $ResourceGroupName
+      TemplateFile            = $TemplateFile
+      TemplateParameterObject = $TemplateParameters
+    }
+
+    $output = Test-AzureRmResourceGroupDeployment @TestTemplateParams
+  
+    It "Should be deployed successfully" {
+      $output | Should -Be $null
+    }
+
+  }
+
+  Context "When a multiple secrets added" {
+    $TemplateParameters = @{
+      keyVaultName = "dfc-foo-bar-kv"
+      secrets      = @( @{ 
+        name   = "foo"
+        secret = "bar"
+        type   = ""
+      }, @{
+        name   = "foo2"
+        secret = "bar2"
+        type   = "text/plain"
+      } )
+    }
+    $TestTemplateParams = @{
+      ResourceGroupName       = $ResourceGroupName
+      TemplateFile            = $TemplateFile
+      TemplateParameterObject = $TemplateParameters
+    }
+
+    $output = Test-AzureRmResourceGroupDeployment @TestTemplateParams
+  
+    It "Should be deployed successfully" {
+      $output | Should -Be $null
+    }
+
+  }
+
+}

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a single key vault secret added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret":" "bar", "type":" "" }]'
+      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret":" "bar", "type":" "" }]')
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -1,6 +1,6 @@
 # common variables
 $ResourceGroupName = "dfc-test-template-rg"
-$TemplateFile = "$PSScriptRoot\..\ArmTemplates\keyvault.json"
+$TemplateFile = "$PSScriptRoot\..\ArmTemplates\keyvault-secrets.json"
 
 Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a single key vault secret added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret": "bar", "type":" "" }]')
+      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret": "bar", "type": "" }]')
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName
@@ -26,8 +26,8 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a multiple secrets added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret": "bar", "type":" "" },
-                      { "name": "foo2", "secret": "another secret", "type":" "text/plain" }]'
+      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret": "bar", "type": "" },
+                      { "name": "foo2", "secret": "another secret", "type": "text/plain" }]'
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName

--- a/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
+++ b/Tests/A007.ArmTemplates.KeyVaultSecrets.Tests.ps1
@@ -26,8 +26,8 @@ Describe "Key Vault Secrets Deployment Tests" -Tag "Acceptance" {
   Context "When a multiple secrets added" {
     $TemplateParameters = @{
       keyVaultName = "dfc-foo-bar-kv"
-      secrets      = ConvertFrom-Json '[{ "name": "foo", "secret": "bar", "type": "" },
-                      { "name": "foo2", "secret": "another secret", "type": "text/plain" }]'
+      secrets      = [Newtonsoft.Json.JsonConvert]::DeserializeObject('[{ "name": "foo", "secret": "bar", "type": "" },
+                      { "name": "foo2", "secret": "another secret", "type": "text/plain" }]')
     }
     $TestTemplateParams = @{
       ResourceGroupName       = $ResourceGroupName

--- a/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
+++ b/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
@@ -2,15 +2,14 @@ Push-Location -Path $PSScriptRoot\..\PSScripts\
 
 Describe "New-KeyVault unit tests" -Tag "Unit" {
 
-    Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "123abc" } ] }' }
-    Mock Remove-AzureRmKeyVaultAccessPolicy
-
     $kvname = "dfc-foobar-kv"
     $rgname = "dfc-foobar-rg"
 
     It "Should create a key vault if one does not exist" {
         Mock Get-AzureRmKeyVault { return $null }
-        Mock Get-AzureRmResourceGroup
+        Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+        Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "123abc" } ] }' }
+        Mock Remove-AzureRmKeyVaultAccessPolicy
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 
@@ -22,7 +21,9 @@ Describe "New-KeyVault unit tests" -Tag "Unit" {
 
     It "Should not create anything if the key vault already exist" {
         Mock Get-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
-        Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+        Mock Get-AzureRmResourceGroup
+        Mock New-AzureRmKeyVault
+        Mock Remove-AzureRmKeyVaultAccessPolicy
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 

--- a/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
+++ b/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
@@ -2,14 +2,15 @@ Push-Location -Path $PSScriptRoot\..\PSScripts\
 
 Describe "New-KeyVault unit tests" -Tag "Unit" {
 
+    Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+    Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "12345678-abcd-1234-5678-1234567890ab" } ] }' }
+    Mock Remove-AzureRmKeyVaultAccessPolicy
+
     $kvname = "dfc-foobar-kv"
     $rgname = "dfc-foobar-rg"
 
     It "Should create a key vault if one does not exist" {
         Mock Get-AzureRmKeyVault { return $null }
-        Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
-        Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "123abc" } ] }' }
-        Mock Remove-AzureRmKeyVaultAccessPolicy
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 
@@ -21,9 +22,6 @@ Describe "New-KeyVault unit tests" -Tag "Unit" {
 
     It "Should not create anything if the key vault already exist" {
         Mock Get-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
-        Mock Get-AzureRmResourceGroup
-        Mock New-AzureRmKeyVault
-        Mock Remove-AzureRmKeyVaultAccessPolicy
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 

--- a/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
+++ b/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
@@ -2,7 +2,6 @@ Push-Location -Path $PSScriptRoot\..\PSScripts\
 
 Describe "New-KeyVault unit tests" -Tag "Unit" {
 
-    Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
     Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "123abc" } ] }' }
     Mock Remove-AzureRmKeyVaultAccessPolicy
 
@@ -11,6 +10,7 @@ Describe "New-KeyVault unit tests" -Tag "Unit" {
 
     It "Should create a key vault if one does not exist" {
         Mock Get-AzureRmKeyVault { return $null }
+        Mock Get-AzureRmResourceGroup
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 
@@ -22,6 +22,7 @@ Describe "New-KeyVault unit tests" -Tag "Unit" {
 
     It "Should not create anything if the key vault already exist" {
         Mock Get-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+        Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
 
         .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
 

--- a/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
+++ b/Tests/U003.PSScripts.New-KeyVault.Tests.ps1
@@ -1,0 +1,36 @@
+Push-Location -Path $PSScriptRoot\..\PSScripts\
+
+Describe "New-KeyVault unit tests" -Tag "Unit" {
+
+    Mock Get-AzureRmResourceGroup { return ConvertFrom-Json '{ "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+    Mock New-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "AccessPolicies": [ { "ObjectId": "123abc" } ] }' }
+    Mock Remove-AzureRmKeyVaultAccessPolicy
+
+    $kvname = "dfc-foobar-kv"
+    $rgname = "dfc-foobar-rg"
+
+    It "Should create a key vault if one does not exist" {
+        Mock Get-AzureRmKeyVault { return $null }
+
+        .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
+
+        Assert-MockCalled Get-AzureRmKeyVault -Exactly 1 -Scope It
+        Assert-MockCalled Get-AzureRmResourceGroup -Exactly 1 -Scope It
+        Assert-MockCalled New-AzureRmKeyVault -Exactly 1 -Scope It
+        Assert-MockCalled Remove-AzureRmKeyVaultAccessPolicy -Exactly 1 -Scope It
+    }
+
+    It "Should not create anything if the key vault already exist" {
+        Mock Get-AzureRmKeyVault { return ConvertFrom-Json '{ "VaultName": "dfc-foobar-kv", "ResourceGroupName": "dfc-foobar-rg", "Location": "westeurope" }' }
+
+        .\New-KeyVault -keyVaultName $kvname -ResourceGroupName $rgname
+
+        Assert-MockCalled Get-AzureRmKeyVault -Exactly 1 -Scope It
+        Assert-MockCalled Get-AzureRmResourceGroup -Exactly 0 -Scope It
+        Assert-MockCalled New-AzureRmKeyVault -Exactly 0 -Scope It
+        Assert-MockCalled Remove-AzureRmKeyVaultAccessPolicy -Exactly 0 -Scope It
+    }
+
+}
+
+Push-Location -Path $PSScriptRoot


### PR DESCRIPTION
The ARM template key vault will always wipe the access policies. The only way around this is to use PowerShell.

Fixed the ARM template to work, updated the docs with this limitation and created a New-KeyVault.ps1 to create a keyvault through PowerShell only if it does not already exist