### PR TITLE
NCSD-374: APIM suffix

### DIFF
--- a/ArmTemplates/APIM/apim-api.json
+++ b/ArmTemplates/APIM/apim-api.json
@@ -26,6 +26,13 @@
             },
             "defaultValue": ""
         },
+        "apiSuffix": {
+            "type":"string",
+            "metadata": {
+              "description": "Relative URL uniquely identifying this API and all of its resource paths within the API Management service instance, defaults to apiName"
+            },
+            "defaultValue": ""
+        },
         "loggerSamplingPercentage": {
             "type": "int",
             "defaultValue": 100,
@@ -42,11 +49,12 @@
     },
     "variables": {
         "apimApiVersionName": "[if(equals(parameters('apiVersion'), ''), parameters('apiName'), concat(parameters('apiName'), '-', parameters('apiVersion')))]",
+        "apiSuffixPath": "[if(equals(parameters('apiSuffix'), ''), parameters('apiName'), parameters('apiSuffix'))]",
         "apiProperties": {
             "noversion": {
                 "authenticationSettings": "[variables('authenticationProvider')]",
                 "displayName": "[variables('apimApiVersionName')]",
-                "path": "[parameters('apiName')]",
+                "path": "[variables('apiSuffixPath')]",
                 "protocols": [
                     "https"
                 ]
@@ -56,7 +64,7 @@
                 "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/api-version-sets', parameters('apimServiceName'), variables('versionSetName'))]",
                 "authenticationSettings": "[variables('authenticationProvider')]",
                 "displayName": "[variables('apimApiVersionName')]",
-                "path": "[parameters('apiName')]",
+                "path": "[variables('apiSuffixPath')]",
                 "protocols": [
                     "https"
                 ]

--- a/ArmTemplates/APIM/apim-api.md
+++ b/ArmTemplates/APIM/apim-api.md
@@ -24,6 +24,12 @@ apiVersion (optional) string
 
 The version of the API.  A version set will need to be created separartely.
 
+apiSuffix (optional) string
+
+Relative URL uniquely identifying this API and all of its resource paths within the API Management service instance.
+It is appended to the API base URL and appears before the path for the API.
+Defaults to the apiName if not specified.
+
 loggerSamplingPercentage (optional) string
 
 Defaults to 100, only applied if apimLoggerName is set.


### PR DESCRIPTION
Added optional apiSuffix to apim-api ARM template to set the path (suffix) to something other than the API name