### PR TITLE
NCSD-1855: DotNet core installer 

### DIFF
--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build-notests.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build-notests.yml
@@ -2,13 +2,20 @@ parameters:
   SolutionBaseName: ''
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'release'
+  DotNetCoreVersion: ''
   PublishWebApp: 'false'
 
 steps:
+ - task: DotNetCoreInstaller@0
+   displayName: 'Use .NET Core sdk ${{ parameters.DotNetCoreVersion }}'
+   condition: ne('', '${{ parameters.DotNetCoreVersion }}')
+   inputs:
+     version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4
    displayName: GitVersion
    inputs:
      preferBundledVersion: false
+
  # tasks to package a function app
  - task: DotNetCoreCLI@2
    displayName: 'dotnet build application'
@@ -24,6 +31,7 @@ steps:
      rootFolderOrFile: $(build.artifactstagingdirectory)\Build\
      archiveFile: $(build.artifactstagingdirectory)\Artifact\DeploymentPackages\$(SolutionBaseName).zip
      includeRootFolder: false
+
 # task to package a web app
  - task: DotNetCoreCLI@2
    displayName: 'dotnet publish application'

--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build-sonar.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build-sonar.yml
@@ -2,12 +2,13 @@ parameters:
   SolutionBaseName: ''
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'release'
-  DotNetCoreVersion: '2.2.101'
+  DotNetCoreVersion: ''
   PublishWebApp: 'false'
 
 steps:
  - task: DotNetCoreInstaller@0
    displayName: 'Use .NET Core sdk ${{ parameters.DotNetCoreVersion }}'
+   condition: ne('', '${{ parameters.DotNetCoreVersion }}')
    inputs:
      version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4

--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
@@ -13,7 +13,7 @@ steps:
    inputs:
      version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4
-   displayName: GitVersion
+   displayName: First non-conditioned task GitVersion
    inputs:
      preferBundledVersion: false
 

--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
@@ -2,13 +2,14 @@ parameters:
   SolutionBaseName: ''
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'release'
-  DotNetCoreVersion: '2.2.101'
+  DotNetCoreVersion: ''
   PublishWebApp: 'false'
   TestSuffix: Tests
 
 steps:
  - task: DotNetCoreInstaller@0
    displayName: 'Use .NET Core sdk ${{ parameters.DotNetCoreVersion }}'
+   condition: ne(${{ parameters.DotNetCoreVersion }}, '')
    inputs:
      version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4

--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
@@ -9,11 +9,11 @@ parameters:
 steps:
  - task: DotNetCoreInstaller@0
    displayName: 'Use .NET Core sdk ${{ parameters.DotNetCoreVersion }}'
-   condition: ne('', ${{ parameters.DotNetCoreVersion }})
+   condition: ne('', '${{ parameters.DotNetCoreVersion }}')
    inputs:
      version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4
-   displayName: First non-conditioned task GitVersion
+   displayName: GitVersion
    inputs:
      preferBundledVersion: false
 

--- a/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
+++ b/AzureDevOpsTemplates/Build/dfc-dotnetcore-build.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
  - task: DotNetCoreInstaller@0
    displayName: 'Use .NET Core sdk ${{ parameters.DotNetCoreVersion }}'
-   condition: ne(${{ parameters.DotNetCoreVersion }}, '')
+   condition: ne('', ${{ parameters.DotNetCoreVersion }})
    inputs:
      version: ${{ parameters.DotNetCoreVersion }}
  - task: gittools.gitversion.gitversion-task.GitVersion@4


### PR DESCRIPTION
Only runs DotNetCoreInstaller task if non-empty DotNetCoreVersion parameter passed into dfc-dotnetcore-build*.yml templates, otherwise task is skipped