### PR TITLE
NCSD-2112: Allows for more than three segments in the resource name

### DIFF
--- a/PSScripts/Get-VersionedFunctionAppName.ps1
+++ b/PSScripts/Get-VersionedFunctionAppName.ps1
@@ -109,7 +109,7 @@ function Get-FunctionAppName {
         throw "Warning: FunctionAppBaseName does not end with -fa, as expected."
     }
 
-    $nameWithoutSuffix = $FunctionAppBaseName -replace "-fa"
+    $nameWithoutSuffix = $FunctionAppBaseName.Substring(0, $FunctionAppBaseName.Length -3)
 
     $versionedName = ($nameWithoutSuffix, $FunctionAppVersion, "fa") -join "-"
 

--- a/PSScripts/Get-VersionedFunctionAppName.ps1
+++ b/PSScripts/Get-VersionedFunctionAppName.ps1
@@ -104,17 +104,16 @@ function Get-FunctionAppName {
         [Parameter(Mandatory=$true)]
         [string] $FunctionAppVersion
     )
-    $Result = $FunctionAppBaseName | Select-String -Pattern "^[a-z]+-[a-z]+-[a-z]+-fa$"
 
-    if (!$Result) {
-        throw "Warning: FunctionAppBaseName variable not set correctly, value $FunctionAppBaseName must match regex ^[a-z]+-[a-z]+-[a-z]+-fa$, eg dss-at-cust-fa"
+    if(-not $FunctionAppBaseName.EndsWith(("-fa"))) {
+        throw "Warning: FunctionAppBaseName does not end with -fa, as expected."
     }
 
-    $NameParts = $FunctionAppBaseName -split "-"
+    $nameWithoutSuffix = $FunctionAppBaseName -replace "-fa"
 
-    $fullAppName = ($NameParts[0..2] -join "-"), $FunctionAppVersion, $NameParts[3] -join "-"
+    $versionedName = ($nameWithoutSuffix, $FunctionAppVersion, "fa") -join "-"
 
-    return $fullAppName
+    return $versionedName
 }
 
 $branchName = $env:Build_SourceBranchName

--- a/Tests/U025.PSScripts.Get-VersionedFunctionAppName.ps1
+++ b/Tests/U025.PSScripts.Get-VersionedFunctionAppName.ps1
@@ -24,6 +24,7 @@ Describe "Get-VersionedFunctionAppName" -Tag "Unit" {
             @{ SourceBranch = "v999999-master"; FunctionBaseName = "dfc-dev-test-fa"; ExpectedResult = "dfc-dev-test-v999999-fa" }
             @{ SourceBranch = "dev-v999999"; FunctionBaseName = "dfc-dev-test-fa"; ExpectedResult = "dfc-dev-test-v999999-fa" }
             @{ SourceBranch = "master-v999999"; FunctionBaseName = "dfc-dev-test-fa"; ExpectedResult = "dfc-dev-test-v999999-fa" }
+            @{ SourceBranch = "dev-v5"; FunctionBaseName = "dfc-dev-draft-component-fa"; ExpectedResult = "dfc-dev-draft-component-v5-fa" }
         )
 
         It "Should return '<ExpectedResult>' for branch <SourceBranch>' and functionName '<FunctionBaseName>'" -TestCases $testData {


### PR DESCRIPTION
We have resources that have 5 (ie: composite draft environment resources) and the job profile api needs 4