### PR TITLE
NCSD-3185: Adds 'update staging slot only' configuration building block

### DIFF
--- a/ArmTemplates/app-service-staging.json
+++ b/ArmTemplates/app-service-staging.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appServiceName": {
+            "type": "string",
+            "metadata": {
+                "description": "App Service name to be created"
+            }
+        },
+        "appServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "App Service Plan to put the app service inside"
+            }
+        },
+        "appServicePlanResourceGroup": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group the App Service Plan is within"
+            }
+        },
+        "appServiceType": {
+            "type": "string",
+            "allowedValues": [
+                "app",
+                "functionapp"
+            ],
+            "defaultValue": "app",
+            "metadata": {
+                "description": "Type of site, either (web)app or functionapp"
+            }
+        },
+        "appServiceAppSettings": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Array of app settings to be created"
+            }
+        },
+        "appServiceConnectionStrings": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Array of connection strings to be created"
+            }
+        },
+        "customHostName": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "certificateThumbprint": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": ""
+            }
+        },
+        "clientAffinity": {
+            "type": "bool",
+            "defaultValue": false
+        }
+    },
+    "variables": {
+        "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",
+        "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('appServiceName')]",
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2018-11-01",
+            "kind": "[parameters('appServiceType')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "serverFarmId": "[variables('appServicePlanId')]",
+                "clientAffinityEnabled": "[parameters('clientAffinity')]",
+                "siteConfig": {
+                    "alwaysOn": true,
+                    "phpVersion": "off"
+                },
+                "httpsOnly": true
+            },
+            "resources": [
+                {
+                    "name": "staging",
+                    "type": "slots",
+                    "apiVersion": "2018-11-01",
+                    "location": "[resourceGroup().location]",
+                    "properties": {
+                        "clientAffinityEnabled": "[parameters('clientAffinity')]",
+                        "siteConfig": {
+                            "appSettings": "[parameters('appServiceAppSettings')]",
+                            "connectionStrings": "[parameters('appServiceConnectionStrings')]",
+                            "phpVersion": "off"
+                        }
+                    },
+                    "dependsOn": [
+                        "[parameters('appServiceName')]"
+                    ]
+                }
+            ],
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Web/sites/hostnameBindings",
+            "condition": "[variables('UseCustomHostname')]",
+            "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
+            "apiVersion": "2016-08-01",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "sslState": "SniEnabled",
+                "thumbprint": "[parameters('certificateThumbprint')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('appServiceName'))]"
+            ]
+        }
+    ],
+    "outputs": {}
+}

--- a/ArmTemplates/app-service-staging.md
+++ b/ArmTemplates/app-service-staging.md
@@ -1,0 +1,79 @@
+# App Service - Staging
+
+Creates an App Service with a staging slot.
+This template only updates the appsettings and connection strings on the staging slot!
+
+## Paramaters
+
+appServiceName: (required) string
+
+Name of App Service. Will be created in the same resource group as the script is run and in the default location for resource group.
+
+appServicePlanName: (required) string
+
+Name of the App Service Plan the app will run inside.
+
+appServicePlanResourceGroup: (optional) string
+
+Resource group the App Service Plan resides in.
+Will default to Standard if not supplied.
+
+appServiceType: (optional) string
+
+Determines whether a web app (app) or a function app (functionapp) is created.
+Creates a web app if not specified.
+
+appServiceAppSettings: (optional) array of object
+
+Array of app settings to be created.
+Will not create any app settings if not supplied.
+Objects in the array must be of the format.
+
+```json
+[
+    {
+        "name": "",
+        "value": ""
+    }
+]
+```
+
+appServiceConnectionStrings: (optional) array of object
+
+Array of connection strings to be created.
+Will not create any connection strings if not supplied.
+Objects in the array must be of the format.
+
+```json
+[
+    {
+        "name": "",
+        "connectionString": "",
+        "type": ""
+    }
+]
+```
+
+customHostName: (optional) string
+
+Custom fully qualified domain name for the app service URL.
+If not provided then the app service will have the URL https://appServiceName.azurewebsites.net/.
+
+In order to specify a custom domain, a CNAME DNS record must be created referencing appServiceName.azurewebsites.net
+
+certificateThumbprint: (optional) string
+
+Thumbprint of the certificate used.
+Only required if the customHostName is supplied above.
+
+This can be passed into the template via the following reference function if an Azure certificate resource has been created:
+> [reference(resourceId(parameters('certificateResourceGroup'), 'Microsoft.Web/certificates', parameters('certificateName')), '2016-03-01').Thumbprint]
+
+clientAffinity: (optional) boolean
+
+Enable ARR Affinity cookie (also known as sticky sessions).
+Often required for stateful web applications.
+Defaults to not enabled (stateless).
+
+If ARR Affinity is enabled the server will place a cookie on responses that causes a user to always hit the same instance within their session.
+This has a load balancing penalty (existing clients cannot be balanced away from an instance running hot) so is disabled by default.


### PR DESCRIPTION
This building block creates an app service with a staging slot.

It only updates the app settings and connection strings on the staging slot of an application.
This is to enhance ZDT support and helps avoid breaking the main slot when deploying app settings updates